### PR TITLE
feat: add labs-phoenix to argocd namespace bidnings

### DIFF
--- a/bootstrap/values-bootstrap.yaml
+++ b/bootstrap/values-bootstrap.yaml
@@ -9,6 +9,7 @@ bootstrap-project:
   dev_namespace: &dev "labs-dev"
   test_namespace: &test "labs-test"
   staging_namespace: &stage "labs-staging"
+  phoenix_namespace: &phoenix "labs-phoenix"
   bindings: &binds
       # this labs-devs is the GROUP NAME in IDM
     - name: who-users
@@ -67,6 +68,7 @@ argocd-operator:
     - name: *dev
     - name: *test
     - name: *stage
+    - name: *phoenix
 
 sealed-secrets:
   # Disabled by default


### PR DESCRIPTION
### Description
While configuring argocd for a new namespace we get an error from argocd stating that it doesn't have privileges for the new namespace. Hence creating this PR hoping that it will fix this error.

### Error message
FATA[0003] rpc error: code = InvalidArgument desc = application spec is invalid: InvalidSpecError: application repo https://github.com/WHOAcademy/lxp-config-dev.git is not permitted in project 'phoenix';InvalidSpecError: application destination {https://kubernetes.default.svc labs-ci-cd} is not permitted in project 'phoenix'